### PR TITLE
Origin Header Check Toggle

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -14,5 +14,5 @@ module.exports = {
         saltRounds: 10,
     },
     allowedOrigins: ['http://localhost:4200', 'http://meme.place'],
-    ensureOrigin: false, // Whether to ensure the origin is in allowedOrigins (for DEV)
+    ensureOrigin: false, // Whether to ensure the origin is in allowedOrigins (default DEV false, PROD true)
 };

--- a/config.example.js
+++ b/config.example.js
@@ -14,4 +14,5 @@ module.exports = {
         saltRounds: 10,
     },
     allowedOrigins: ['http://localhost:4200', 'http://meme.place'],
+    ensureOrigin: false, // Whether to ensure the origin is in allowedOrigins (for DEV)
 };

--- a/config.example.js
+++ b/config.example.js
@@ -14,5 +14,6 @@ module.exports = {
         saltRounds: 10,
     },
     allowedOrigins: ['http://localhost:4200', 'http://meme.place'],
-    ensureOrigin: false, // Whether to ensure the origin is in allowedOrigins (default DEV false, PROD true)
+    ensureOrigin: false, // Ensure origin is in allowedOrigins
+                         // (default DEV false, PROD true)
 };

--- a/index.js
+++ b/index.js
@@ -10,13 +10,20 @@ if (!config.session.secret) {
     throw new Error('You must fill in the session secret in the config')
 }
 
-if (config.ensureOrigin === undefined) {
-    config.ensureOrigin = true;
-}
-
 if (app.get('env') === 'production') {
     app.set('trust proxy', 1);
     config.session.cookie.secure = true;
+
+    // Defaults ensureOrigin to true
+    if (config.ensureOrigin === false) {
+        console.error('Warning: Origin checking should not be disabled in production');
+    }
+    else {
+        config.ensureOrigin = true;
+    }
+}
+else {
+    config.ensureOrigin = config.ensureOrigin || false;
 }
 
 app.use(bodyParser.json());

--- a/index.js
+++ b/index.js
@@ -10,6 +10,10 @@ if (!config.session.secret) {
     throw new Error('You must fill in the session secret in the config')
 }
 
+if (config.ensureOrigin === undefined) {
+    config.ensureOrigin = true;
+}
+
 if (app.get('env') === 'production') {
     app.set('trust proxy', 1);
     config.session.cookie.secure = true;
@@ -29,8 +33,10 @@ app.use((req, res, next) => {
     if (!origin || (config.allowedOrigins || []).indexOf(origin) > -1) {
         res.header('Access-Control-Allow-Origin', origin);
         next();
-    } else {
+    } else if (config.ensureOrigin) {
         res.status(400).json({error: 'Invalid request origin'});
+    } else {
+        next();
     }
 });
 app.use(session(config.session));


### PR DESCRIPTION
Some network debuggers can't fake the `Origin` header, and would therefore not work with our current setup in development.

This PR defaults to `Origin` header checking off in development and on in production. This can be overridden in the config file, and will output a warning if it is forced off in production.